### PR TITLE
Bug_Fixes

### DIFF
--- a/fortinet-fortivoice/connector.py
+++ b/fortinet-fortivoice/connector.py
@@ -8,7 +8,7 @@
 from connectors.core.connector import Connector, get_logger, ConnectorError
 from .operations import operations, _check_health
 
-logger = get_logger('fortivoice')
+logger = get_logger('fortinet-fortivoice')
 
 
 class FortiVoiceConnector(Connector):

--- a/fortinet-fortivoice/info.json
+++ b/fortinet-fortivoice/info.json
@@ -161,7 +161,7 @@
     },
     {
       "operation": "apply_the_uploaded_file",
-      "title": "Apply The Uploaded File",
+      "title": "Apply The Uploaded License File",
       "annotation": "apply_the_uploaded_file",
       "description": "Apply the uploaded license file to Fortinet FortiVoice.",
       "visible": true,

--- a/fortinet-fortivoice/info.json
+++ b/fortinet-fortivoice/info.json
@@ -125,7 +125,7 @@
         {
           "title": "Size",
           "name": "size",
-          "required": true,
+          "required": false,
           "editable": true,
           "visible": true,
           "type": "integer",
@@ -141,6 +141,7 @@
       "title": "Upload License File",
       "annotation": "upload_license_file",
       "description": "Uploads license file to Fortinet FortiVoice.",
+      "category": "investigation",
       "visible": true,
       "enabled": true,
       "output_schema": {
@@ -164,6 +165,7 @@
       "title": "Apply The Uploaded License File",
       "annotation": "apply_the_uploaded_file",
       "description": "Apply the uploaded license file to Fortinet FortiVoice.",
+      "category": "investigation",
       "visible": true,
       "enabled": true,
       "output_schema": {

--- a/fortinet-fortivoice/operations.py
+++ b/fortinet-fortivoice/operations.py
@@ -10,7 +10,7 @@ from .constants import *
 from connectors.core.utils import update_connnector_config
 from integrations.crudhub import make_request
 
-logger = get_logger('fortivoice')
+logger = get_logger('fortinet-fortivoice')
 
 
 class FortiVoice(object):
@@ -82,8 +82,8 @@ def get_devices_list(config, params):
     req_params = {
         'reqAction': 1,
         'mdomain': 'system',
-        'startIndex': params.get('start_index', 0),
-        'pageSize': params.get('size'),
+        'startIndex': params.get('start_index') if params.get('start_index') else 0,
+        'pageSize': params.get('size') if params.get('size') else 50,
     }
     search_pattern = params.get('search_mac_address')
     if search_pattern:

--- a/fortinet-fortivoice/playbooks/playbooks.json
+++ b/fortinet-fortivoice/playbooks/playbooks.json
@@ -183,7 +183,7 @@
           "collection": "/api/3/workflow_collections/94fe426f-cc15-4705-b19d-8e029567a536",
           "triggerLimit": null,
           "description": "Apply the uploaded license file to Fortinet FortiVoice.",
-          "name": "Apply The Uploaded File",
+          "name": "Apply The Uploaded License File",
           "tag": "#Fortinet FortiVoice",
           "recordTags": [
             "Fortinet",
@@ -204,7 +204,7 @@
               "status": null,
               "arguments": {
                 "route": "ac7159e6-02cb-4c43-9777-da32860510ea",
-                "title": "Fortinet FortiVoice: Apply The Uploaded File",
+                "title": "Fortinet FortiVoice: Apply The Uploaded License File",
                 "resources": [
                   "alerts"
                 ],
@@ -225,7 +225,7 @@
             {
               "uuid": "15004254-1ebd-4a70-9954-fc58e7093e05",
               "@type": "WorkflowStep",
-              "name": "Apply The Uploaded File",
+              "name": "Apply The Uploaded License File",
               "description": null,
               "status": null,
               "arguments": {
@@ -235,7 +235,7 @@
                 "version": "1.0.0",
                 "connector": "fortinet-fortivoice",
                 "operation": "apply_the_uploaded_file",
-                "operationTitle": "Apply The Uploaded File",
+                "operationTitle": "Apply The Uploaded License File",
                 "step_variables": {
                   "output_data": "{{vars.result}}"
                 }
@@ -251,7 +251,7 @@
               "uuid": "db64ede9-95f6-4b50-ad16-91a7a2909774",
               "label": null,
               "isExecuted": false,
-              "name": "Start-> Apply The Uploaded File",
+              "name": "Start-> Apply The Uploaded License File",
               "sourceStep": "/api/3/workflow_steps/9357e324-1aa7-47e2-afed-4e3950e669ae",
               "targetStep": "/api/3/workflow_steps/15004254-1ebd-4a70-9954-fc58e7093e05"
             }


### PR DESCRIPTION
### Descriptions:
#### Changes:
- updated logger
- Updated action title `Apply The Uploaded File` to `Apply The Uploaded License File`
- Pagination parameter `Size` in `Get Devices List` action changed to optional.
- Added action category to `Apply The Uploaded License File` and `Upload License File` actions.

#### Mantis:
- 0922852 :  In Get Devices List action mandatory fields should written first.
- 0922494 : Category is missing for 2 connector actions 'Upload license File' and 'Apply the uploaded license File'
- 0922443 : Change the action name from "Apply the Uploaded File" to "Apply the Uploaded License File"

#### UTC's:

- [x] Verified title of action  `Apply The Uploaded License File`
- [x] Tested and verified `Size` parameter in `Get Devices List` action.
- [x] Verified category of `Apply The Uploaded License File` and `Upload License File` actions.
- [x] Verified logger name.

